### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/SSpace.h
+++ b/SSpace.h
@@ -1211,11 +1211,11 @@ void outputTable(vec v, vector<string>& table){
   uvec ind;
   if (n4 < 168){
     if (n < 30)
-        ind << 0 << 1 << 2 << 3 << endr;
+        ind = { 0, 1, 2, 3 };
     else
-        ind << 0 << 3 << 7 << 11 << endr;
+        ind = { 0, 3, 7, 11 };
   } else {
-    ind << 0 << 3 << 7 << 11 << 23 << 167 << endr;
+    ind = { 0, 3, 7, 11, 23, 167 };
   }
   int ncoef = ind.max() + 1;
   vec acfCoef1, acfCoef2;


### PR DESCRIPTION
These three one-line change update RcppArmadillo from the now deprecated << initialization to brace initialization allowed since C++11 and long been the minimal standard with R too. It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391